### PR TITLE
Use "set number"

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -276,7 +276,7 @@ set hlsearch
 " http://stackoverflow.com/questions/762515/vim-remap-key-to-toggle-line-numbering
 set nowrap
 noremap <silent><F1> :set wrap!<CR>
-set nonumber
+set number
 noremap <silent><F2> :set number!<CR>
 set ruler
 set ignorecase

--- a/setup.sh
+++ b/setup.sh
@@ -55,6 +55,8 @@ if [ $(uname) = Darwin ]; then
     reattach-to-user-namespace
     gawk
     parallel
+    mysql
+    sqlite
   )
 
   for brew_name in "${brew_names[@]}"; do


### PR DESCRIPTION
Because of error messages that indicates a line number.